### PR TITLE
Declare build system dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["numpy", "setuptools", "wheel"]


### PR DESCRIPTION
When I try to install `ridge_significance` with
```bash
pip install git+https://github.com/data2intelligence/ridge_significance.git@main
```
it fails due to numpy not being available at install time (see traceback below). This PR solves the issue by 
declaring numpy as build-system dependency in `pyproject.toml`. 

```pytb
Collecting git+https://github.com/data2intelligence/ridge_significance.git@main
  Cloning https://github.com/data2intelligence/ridge_significance.git (to revision main) to /home/sturm/tmp/pip-req-build-mrphuoxp
  Running command git clone --filter=blob:none -q https://github.com/data2intelligence/ridge_significance.git /home/sturm/tmp/pip-req-build-mrphuoxp
  Resolved https://github.com/data2intelligence/ridge_significance.git to commit 9c8d1c10ab9dda218ceaf5e05e4df9f1e84ca5f8
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/sturm/anaconda3/envs/test_cytosig/bin/python3.8 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/sturm/tmp/pip-req-build-mrphuoxp/setup.py'"'"'; __file__='"'"'/home/sturm/tmp/pip-req-build-mrphuoxp/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /home/sturm/tmp/pip-pip-egg-info-0k07cywp
       cwd: /home/sturm/tmp/pip-req-build-mrphuoxp/
  Complete output (5 lines):
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/sturm/tmp/pip-req-build-mrphuoxp/setup.py", line 2, in <module>
      import os, numpy
  ModuleNotFoundError: No module named 'numpy'
  ----------------------------------------
WARNING: Discarding git+https://github.com/data2intelligence/ridge_significance.git@main. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```